### PR TITLE
♻️ refactor: skip caddy prd checks + ignore md paths in CI

### DIFF
--- a/.github/actions/deploy-vps/action.yml
+++ b/.github/actions/deploy-vps/action.yml
@@ -110,5 +110,10 @@ runs:
           }
 
           check "HTTP  localhost:${PORT}/health" "http://localhost:${PORT}/health"
-          check "HTTPS ${DOMAIN}/"               "https://${DOMAIN}/"
-          check "HTTPS ${DOMAIN}/health"         "https://${DOMAIN}/health"
+
+          # Caddy/HTTPS checks skipped for prd — DNS + TLS provisioning may not be
+          # instant; the HTTP health above confirms the app is running.
+          if [ "${{ inputs.target_env }}" != "master" ]; then
+            check "HTTPS ${DOMAIN}/"       "https://${DOMAIN}/"
+            check "HTTPS ${DOMAIN}/health" "https://${DOMAIN}/health"
+          fi

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -4,6 +4,9 @@ on:
   pull_request:
     types: [opened, synchronize, reopened, closed]
     branches: [dev, master]
+    paths-ignore:
+      - 'GUIDE.md'
+      - '**.md'
 
 # Preview builds: cancel previous (fast feedback).
 # Deploys (closed event): queue, don't cancel mid-deploy.

--- a/GUIDE.md
+++ b/GUIDE.md
@@ -308,7 +308,7 @@ Use this when rotating keys or when the account already exists and is working.
 **On your local machine** — generate a new key pair:
 
 ```bash
-ssh-keygen -t ed25519 -C "gh-action-forex-tools-deployBoiz" -f ~/.ssh/deployBoiz_ed25519_new
+ssh-keygen -t ed25519 -C "gh-action-forex-tools-dev-deployBoiz" -f ~/.ssh/forex-tools-dev-deployBoiz
 ```
 
 **On the VPS (as root)** — replace the old key:
@@ -326,7 +326,7 @@ cat /home/deployBoiz/.ssh/authorized_keys
 **Test before updating GitHub secret:**
 
 ```bash
-ssh -i ~/.ssh/deployBoiz_ed25519_new \
+ssh -i ~/.ssh/forex-tools-dev-deployBoiz \
     -p <VPS_SSH_PORT> \
     -o PasswordAuthentication=no \
     deployBoiz@<VPS_HOST> "echo ok"


### PR DESCRIPTION
- `deploy-vps`: skip HTTPS/Caddy health checks for `master` env — only HTTP localhost check runs on prd
- `pr.yml`: add `paths-ignore: ['**.md']` — doc-only pushes no longer trigger builds
- `GUIDE.md`: update SSH key naming convention to `forex-tools-dev-deployBoiz`
