### PR TITLE
Refactor CI/CD workflows for tag-triggered releases and path ignores

### DIFF
--- a/.github/actions/build-docker/action.yml
+++ b/.github/actions/build-docker/action.yml
@@ -9,8 +9,13 @@ inputs:
     required: true
     description: "Target environment (dev or master)"
   extra_tag:
-    required: true
-    description: "Additional tag: 'pr-N' for preview or 'latest' for release"
+    required: false
+    default: ""
+    description: "Secondary tag (e.g. 'pr-N' or 'latest'). Empty to skip."
+  semver_tag:
+    required: false
+    default: ""
+    description: "Semver release tag (e.g. 'v1.2.3'). Empty to skip. Used by master tag-push releases."
   sha:
     required: true
     description: "Commit SHA"
@@ -43,15 +48,19 @@ runs:
         IMAGE="ghcr.io/${{ inputs.owner_lc }}/forextools-${{ inputs.target_env }}"
         SHA="${{ inputs.sha }}"
         EXTRA="${{ inputs.extra_tag }}"
+        SEMVER="${{ inputs.semver_tag }}"
 
-        echo "🏗 Building $IMAGE:$SHA (+$EXTRA)"
+        TAG_ARGS=( -t "$IMAGE:$SHA" )
+        [[ -n "$EXTRA"  ]] && TAG_ARGS+=( -t "$IMAGE:$EXTRA" )
+        [[ -n "$SEMVER" ]] && TAG_ARGS+=( -t "$IMAGE:$SEMVER" )
+
+        echo "🏗 Building $IMAGE with tags: ${TAG_ARGS[*]}"
 
         docker buildx build \
           --cache-from type=gha \
           --cache-to type=gha,mode=max \
           --push \
-          -t "$IMAGE:$SHA" \
-          -t "$IMAGE:$EXTRA" \
+          "${TAG_ARGS[@]}" \
           .
 
         echo "image_tag=$IMAGE:$SHA" >> "$GITHUB_OUTPUT"

--- a/.github/actions/deploy-summary/action.yml
+++ b/.github/actions/deploy-summary/action.yml
@@ -8,6 +8,13 @@ inputs:
   job-status:
     required: true
     description: "JSON of job results from needs context"
+  mode:
+    required: true
+    description: "pr-preview | pr-deploy | release"
+  release_tag:
+    required: false
+    default: ""
+    description: "Semver tag, only for mode=release"
 
 runs:
   using: "composite"
@@ -18,4 +25,4 @@ runs:
         GH_TOKEN: ${{ github.token }}
         GITHUB_TOKEN: ${{ github.token }}
         JOB_STATUS_JSON: ${{ inputs.job-status }}
-      run: bash "${{ github.action_path }}/summary.sh" "${{ inputs.target_env }}"
+      run: bash "${{ github.action_path }}/summary.sh" "${{ inputs.target_env }}" "${{ inputs.mode }}" "${{ inputs.release_tag }}"

--- a/.github/actions/deploy-summary/summary.sh
+++ b/.github/actions/deploy-summary/summary.sh
@@ -1,7 +1,10 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-ENV=$1
+ENV="$1"
+MODE="$2"
+RELEASE_TAG="${3:-}"
+
 REPO="${GITHUB_REPOSITORY}"
 OWNER="${GITHUB_REPOSITORY_OWNER}"
 REPO_NAME=$(basename "$REPO")
@@ -19,12 +22,14 @@ esac
 IMAGE_NAME="forextools-${ENV}"
 CURRENT_TAG="ghcr.io/${OWNER}/${IMAGE_NAME}:${GITHUB_SHA}"
 RUN_URL="${GITHUB_SERVER_URL}/${REPO}/actions/runs/${GITHUB_RUN_ID}"
-VAR_NAME="LAST_GOOD_SHA_${ENV^^}"
+
+if [[ "$MODE" == "release" && -n "$RELEASE_TAG" ]]; then
+  RELEASE_IMAGE="ghcr.io/${OWNER}/${IMAGE_NAME}:${RELEASE_TAG}"
+fi
 
 # ── Parse job results into Markdown table ──────────────────
 TABLE="| Job | Result |"$'\n'"|-----|--------|"
 ANY_FAIL=false
-DEPLOY_RESULT="skipped"
 
 while IFS="=" read -r JOB RES; do
   case $RES in
@@ -34,68 +39,56 @@ while IFS="=" read -r JOB RES; do
     cancelled) ICON="🛑"; ANY_FAIL=true ;;
     *)         ICON="❓" ;;
   esac
-  [[ "$JOB" == "deploy" ]] && DEPLOY_RESULT="$RES"
   TABLE+=$'\n'"| ${JOB} | ${ICON} ${RES} |"
 done < <(jq -r 'to_entries[] | "\(.key)=\(.value.result)"' <<<"$JOB_STATUS_JSON")
 
-# ── Track last good SHA ────────────────────────────────────
-ROLLBACK_SHA=""
-ROLLBACK_SOURCE=""
-
-if [[ "$DEPLOY_RESULT" == "success" ]]; then
-  # Save current SHA as the last known good
-  if gh api "repos/${OWNER}/${REPO_NAME}/actions/variables/${VAR_NAME}" --jq '.id' >/dev/null 2>&1; then
-    gh api -X PATCH -H "Accept: application/vnd.github+json" \
-      "repos/${OWNER}/${REPO_NAME}/actions/variables/${VAR_NAME}" \
-      -f value="$GITHUB_SHA" >/dev/null 2>&1 || echo "⚠️ Failed to update $VAR_NAME"
-  else
-    gh api -X POST -H "Accept: application/vnd.github+json" \
-      "repos/${OWNER}/${REPO_NAME}/actions/variables" \
-      -f name="${VAR_NAME}" -f value="$GITHUB_SHA" >/dev/null 2>&1 || echo "⚠️ Failed to create $VAR_NAME"
-  fi
-  ROLLBACK_SHA="$GITHUB_SHA"
-  ROLLBACK_SOURCE="(this deploy)"
-else
-  # Look up last known good SHA
-  ROLLBACK_SHA=$(gh api -H "Accept: application/vnd.github+json" \
-    "repos/${OWNER}/${REPO_NAME}/actions/variables/${VAR_NAME}" \
-    --jq '.value' 2>/dev/null || true)
-
-  if [[ -z "$ROLLBACK_SHA" || "$ROLLBACK_SHA" == "null" || "$ROLLBACK_SHA" == *"Not Found"* ]]; then
-    ROLLBACK_SHA="$GITHUB_SHA"
-    ROLLBACK_SOURCE="(⚠️ no recorded good deploy — fallback to current)"
-  else
-    ROLLBACK_SOURCE="(last successful deploy)"
-  fi
-fi
-
-ROLLBACK_SHA_SHORT=$(echo "$ROLLBACK_SHA" | cut -c1-7)
-ROLLBACK_TAG="ghcr.io/${OWNER}/${IMAGE_NAME}:${ROLLBACK_SHA}"
-
 # ── Build conclusion message ───────────────────────────────
 if [[ "$ANY_FAIL" == true ]]; then
-  STATUS="❌ Some jobs failed in **${ENV}** (\`${SHA_SHORT}\`)."
+  STATUS_LINE="❌ Some jobs failed in **${ENV}** (\`${SHA_SHORT}\`)."
+  LINKS="📜 [View Logs](${RUN_URL})"
 else
-  STATUS="✅ All jobs passed in **${ENV}** (\`${SHA_SHORT}\`)."
+  STATUS_LINE="✅ All jobs passed in **${ENV}** (\`${SHA_SHORT}\`)."
+  LINKS="🔗 [Open App](${DOMAIN}) | 📜 [View Logs](${RUN_URL})"
 fi
 
-if [[ "$ANY_FAIL" == false ]]; then
-  HEADER="${STATUS}
-🔗 [Open App](${DOMAIN}) | 📜 [View Logs](${RUN_URL})"
-else
-  HEADER="${STATUS}
-📜 [View Logs](${RUN_URL})"
-fi
+case "$MODE" in
+  pr-preview)
+    CONCLUSION="${STATUS_LINE}
+${LINKS}
 
-CONCLUSION="${HEADER}
+🖼 **Preview image:** \`${CURRENT_TAG}\`"
+    ;;
+  pr-deploy)
+    CONCLUSION="${STATUS_LINE}
+${LINKS}
 
-🖼 **Image:** \`${CURRENT_TAG}\`
-🔄 **Rollback:** \`${ROLLBACK_SHA_SHORT}\` ${ROLLBACK_SOURCE}
+🖼 **Image:** \`${CURRENT_TAG}\`"
+    ;;
+  release)
+    TAGS_URL="${GITHUB_SERVER_URL}/${REPO}/tags"
+    NEXT_PATCH=$(awk -F. -v t="$RELEASE_TAG" 'BEGIN{sub(/^v/,"",t); split(t,a,"."); printf "v%d.%d.%d", a[1], a[2], a[3]+1}')
+    CONCLUSION="${STATUS_LINE}
+${LINKS}
+
+🏷 **Release:** \`${RELEASE_TAG}\`
+🖼 **Image:** \`${RELEASE_IMAGE}\` (also \`${CURRENT_TAG}\`, \`:latest\`)
+📜 **All tags:** [view](${TAGS_URL})
+
+#### To roll back
+Push a new, higher tag pointing at an older commit:
 \`\`\`bash
-cd /opt/projects/forextools-${ENV}
-export IMAGE_TAG=${ROLLBACK_TAG}
-docker compose -f docker-compose.yml -f docker-compose.${ENV}.yml up -d --force-recreate
+git tag -a ${NEXT_PATCH} <older-good-commit-sha> -m \"Rollback\"
+git push origin ${NEXT_PATCH}
 \`\`\`"
+    ;;
+  *)
+    echo "⚠️ Unknown mode: $MODE" >&2
+    CONCLUSION="${STATUS_LINE}
+${LINKS}
+
+🖼 **Image:** \`${CURRENT_TAG}\`"
+    ;;
+esac
 
 # ── Write to GitHub Step Summary ──────────────────────────
 {

--- a/.github/actions/deploy-vps/action.yml
+++ b/.github/actions/deploy-vps/action.yml
@@ -110,5 +110,10 @@ runs:
           }
 
           check "HTTP  localhost:${PORT}/health" "http://localhost:${PORT}/health"
-          check "HTTPS ${DOMAIN}/"               "https://${DOMAIN}/"
-          check "HTTPS ${DOMAIN}/health"         "https://${DOMAIN}/health"
+
+          # Caddy/HTTPS checks skipped for prd — DNS + TLS provisioning may not be
+          # instant; the HTTP health above confirms the app is running.
+          if [ "${{ inputs.target_env }}" != "master" ]; then
+            check "HTTPS ${DOMAIN}/"       "https://${DOMAIN}/"
+            check "HTTPS ${DOMAIN}/health" "https://${DOMAIN}/health"
+          fi

--- a/.github/actions/deploy-vps/action.yml
+++ b/.github/actions/deploy-vps/action.yml
@@ -29,6 +29,10 @@ inputs:
   twelve_data_api_key:
     required: true
     description: "Twelve Data API key for price fetching"
+  display_tag:
+    required: false
+    default: ""
+    description: "Human-readable tag shown in logs (e.g. 'v1.2.3'). Cosmetic only — pull is always by SHA."
 
 runs:
   using: "composite"
@@ -66,6 +70,10 @@ runs:
 
           # ── Docker login & pull ──────────────────────────────
           echo "${{ inputs.gh_token }}" | docker login ghcr.io -u "${{ github.actor }}" --password-stdin
+
+          if [ -n "${{ inputs.display_tag }}" ]; then
+            echo "🏷 Release: ${{ inputs.display_tag }}"
+          fi
 
           IMAGE_TAG="ghcr.io/${{ inputs.owner_lc }}/forextools-${{ inputs.target_env }}:${{ inputs.sha }}"
           echo "📦 Pulling $IMAGE_TAG"

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -1,4 +1,4 @@
-name: CI/CD
+name: PR CI/CD
 
 on:
   pull_request:
@@ -8,7 +8,7 @@ on:
 # Preview builds: cancel previous (fast feedback).
 # Deploys (closed event): queue, don't cancel mid-deploy.
 concurrency:
-  group: cicd-${{ github.event.pull_request.base.ref }}-${{ github.event.pull_request.number }}
+  group: pr-${{ github.event.pull_request.base.ref }}-${{ github.event.pull_request.number }}
   cancel-in-progress: ${{ github.event.action != 'closed' }}
 
 permissions:
@@ -34,7 +34,7 @@ jobs:
         run: echo "owner_lc=$(echo '${{ github.repository_owner }}' | tr '[:upper:]' '[:lower:]')" >> "$GITHUB_OUTPUT"
 
   # ────────────────────────────────────────────────────────────
-  # BUILD PREVIEW — every push to an open PR
+  # BUILD PREVIEW — every push to an open PR (dev or master)
   # ────────────────────────────────────────────────────────────
   build-preview:
     needs: setup
@@ -51,37 +51,38 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
 
   # ────────────────────────────────────────────────────────────
-  # BUILD RELEASE — when PR is merged
+  # BUILD RELEASE DEV — when a PR is merged into dev
+  # (master releases are handled by release.yml on tag push)
   # ────────────────────────────────────────────────────────────
-  build-release:
+  build-release-dev:
     needs: setup
-    if: github.event.pull_request.merged == true
+    if: github.event.pull_request.merged == true && github.event.pull_request.base.ref == 'dev'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/build-docker
         with:
           owner_lc: ${{ needs.setup.outputs.owner_lc }}
-          target_env: ${{ env.ENV }}
+          target_env: dev
           extra_tag: latest
           sha: ${{ github.sha }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
 
   # ────────────────────────────────────────────────────────────
-  # DEPLOY — pull image, compose up, health check
+  # DEPLOY DEV — pull image, compose up, health check
   # ────────────────────────────────────────────────────────────
-  deploy:
-    needs: [setup, build-release]
-    if: github.event.pull_request.merged == true
+  deploy-dev:
+    needs: [setup, build-release-dev]
+    if: github.event.pull_request.merged == true && github.event.pull_request.base.ref == 'dev'
     runs-on: ubuntu-latest
-    environment: ${{ github.event.pull_request.base.ref }}
+    environment: dev
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/deploy-vps
         with:
           owner_lc: ${{ needs.setup.outputs.owner_lc }}
-          target_env: ${{ env.ENV }}
+          target_env: dev
           sha: ${{ github.sha }}
           gh_token: ${{ secrets.GITHUB_TOKEN }}
           vps_host: ${{ secrets.VPS_HOST }}
@@ -94,10 +95,10 @@ jobs:
           twelve_data_api_key: ${{ secrets.TWELVE_DATA_API_KEY }}
 
   # ────────────────────────────────────────────────────────────
-  # CLEANUP — delete leftovers from GHCR
+  # CLEANUP — delete leftovers from GHCR on PR close
   # ────────────────────────────────────────────────────────────
   cleanup:
-    needs: [setup, deploy]
+    needs: [setup, deploy-dev]
     if: always() && github.event.action == 'closed'
     runs-on: ubuntu-latest
     steps:
@@ -114,7 +115,7 @@ jobs:
   # SUMMARY — post results to PR comment + step summary
   # ────────────────────────────────────────────────────────────
   summary:
-    needs: [build-preview, build-release, deploy, cleanup]
+    needs: [build-preview, build-release-dev, deploy-dev, cleanup]
     if: always()
     runs-on: ubuntu-latest
     steps:
@@ -122,4 +123,5 @@ jobs:
       - uses: ./.github/actions/deploy-summary
         with:
           target_env: ${{ env.ENV }}
+          mode: ${{ (github.event.pull_request.merged == true && github.event.pull_request.base.ref == 'dev') && 'pr-deploy' || 'pr-preview' }}
           job-status: ${{ toJSON(needs) }}

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -4,6 +4,9 @@ on:
   pull_request:
     types: [opened, synchronize, reopened, closed]
     branches: [dev, master]
+    paths-ignore:
+      - 'GUIDE.md'
+      - '**.md'
 
 # Preview builds: cancel previous (fast feedback).
 # Deploys (closed event): queue, don't cancel mid-deploy.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,173 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v[0-9]+.[0-9]+.[0-9]+'   # glob pre-filter; strict regex enforced in validate-tag
+
+# Serialize simultaneous tag pushes; never cancel an in-flight deploy.
+concurrency:
+  group: release-master
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+  packages: write
+  actions: write
+
+jobs:
+  # ────────────────────────────────────────────────────────────
+  # Lowercase the repo owner (GHCR requires lowercase paths)
+  # ────────────────────────────────────────────────────────────
+  setup:
+    runs-on: ubuntu-latest
+    outputs:
+      owner_lc: ${{ steps.vars.outputs.owner_lc }}
+    steps:
+      - id: vars
+        run: echo "owner_lc=$(echo '${{ github.repository_owner }}' | tr '[:upper:]' '[:lower:]')" >> "$GITHUB_OUTPUT"
+
+  # ────────────────────────────────────────────────────────────
+  # VALIDATE TAG — strict SemVer + monotonic version guard
+  # ────────────────────────────────────────────────────────────
+  validate-tag:
+    needs: setup
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.guard.outputs.version }}
+      commit_sha: ${{ steps.guard.outputs.commit_sha }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          fetch-tags: true
+
+      - id: guard
+        shell: bash
+        run: |
+          set -euo pipefail
+          TAG="${GITHUB_REF_NAME}"
+          STRICT='^v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$'
+
+          # 1. Strict format check (rejects v1.2, v01.02.03, v1.2.3-rc1, v1.2.3+meta)
+          if [[ ! "$TAG" =~ $STRICT ]]; then
+            {
+              echo "## ❌ Invalid release tag"
+              echo ""
+              echo "Tag \`$TAG\` does not match strict SemVer \`vMAJOR.MINOR.PATCH\`."
+              echo ""
+              echo "**Rules:**"
+              echo "- Must start with \`v\`"
+              echo "- Three numeric components, no leading zeros"
+              echo "- No pre-release suffix (\`-rc1\`), no build metadata (\`+build\`)"
+              echo ""
+              echo "Examples: \`v1.0.0\`, \`v2.10.3\`, \`v0.0.1\`"
+            } >> "$GITHUB_STEP_SUMMARY"
+            exit 1
+          fi
+
+          # 2. Find previous highest tag (exclude THIS tag)
+          PREV=$(git tag --list 'v*.*.*' \
+            | grep -E "$STRICT" \
+            | grep -vxF "$TAG" \
+            | sort -V \
+            | tail -n1 || true)
+
+          # 3. First-ever release: pass
+          if [[ -z "$PREV" ]]; then
+            echo "version=$TAG" >> "$GITHUB_OUTPUT"
+            echo "commit_sha=$GITHUB_SHA" >> "$GITHUB_OUTPUT"
+            {
+              echo "## ✅ Release tag accepted"
+              echo ""
+              echo "- Tag: \`$TAG\` (first release)"
+              echo "- Commit: \`$(git rev-parse --short "$GITHUB_SHA")\`"
+            } >> "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+
+          # 4. Strict-greater check via version sort
+          HIGHEST=$(printf '%s\n%s\n' "$PREV" "$TAG" | sort -V | tail -n1)
+          if [[ "$HIGHEST" != "$TAG" || "$PREV" == "$TAG" ]]; then
+            {
+              echo "## ❌ Version not strictly increasing"
+              echo ""
+              echo "- New tag: \`$TAG\`"
+              echo "- Previous highest: \`$PREV\`"
+              echo ""
+              echo "Push a tag strictly greater than \`$PREV\`."
+            } >> "$GITHUB_STEP_SUMMARY"
+            exit 1
+          fi
+
+          echo "version=$TAG" >> "$GITHUB_OUTPUT"
+          echo "commit_sha=$GITHUB_SHA" >> "$GITHUB_OUTPUT"
+          {
+            echo "## ✅ Release tag accepted"
+            echo ""
+            echo "- New tag: \`$TAG\`"
+            echo "- Previous highest: \`$PREV\`"
+            echo "- Commit: \`$(git rev-parse --short "$GITHUB_SHA")\`"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+  # ────────────────────────────────────────────────────────────
+  # BUILD RELEASE — fresh image from the tagged commit
+  # ────────────────────────────────────────────────────────────
+  build-release-master:
+    needs: [setup, validate-tag]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/build-docker
+        with:
+          owner_lc: ${{ needs.setup.outputs.owner_lc }}
+          target_env: master
+          extra_tag: latest
+          semver_tag: ${{ needs.validate-tag.outputs.version }}
+          sha: ${{ github.sha }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+
+  # ────────────────────────────────────────────────────────────
+  # DEPLOY — pull image, compose up, health check
+  # ────────────────────────────────────────────────────────────
+  deploy-master:
+    needs: [setup, validate-tag, build-release-master]
+    runs-on: ubuntu-latest
+    environment: master
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/deploy-vps
+        with:
+          owner_lc: ${{ needs.setup.outputs.owner_lc }}
+          target_env: master
+          sha: ${{ github.sha }}
+          display_tag: ${{ needs.validate-tag.outputs.version }}
+          gh_token: ${{ secrets.GITHUB_TOKEN }}
+          vps_host: ${{ secrets.VPS_HOST }}
+          vps_user: ${{ secrets.VPS_USER }}
+          vps_ssh_key: ${{ secrets.VPS_SSH_KEY }}
+          vps_ssh_port: ${{ secrets.VPS_SSH_PORT }}
+          dev_domain: ${{ vars.DEV_DOMAIN }}
+          prd_domain: ${{ vars.PRD_DOMAIN }}
+          port: ${{ vars.PORT }}
+          twelve_data_api_key: ${{ secrets.TWELVE_DATA_API_KEY }}
+
+  # ────────────────────────────────────────────────────────────
+  # SUMMARY — post results to step summary
+  # ────────────────────────────────────────────────────────────
+  summary:
+    needs: [validate-tag, build-release-master, deploy-master]
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          fetch-tags: true
+      - uses: ./.github/actions/deploy-summary
+        with:
+          target_env: master
+          mode: release
+          release_tag: ${{ needs.validate-tag.outputs.version }}
+          job-status: ${{ toJSON(needs) }}

--- a/GUIDE.md
+++ b/GUIDE.md
@@ -308,7 +308,7 @@ Use this when rotating keys or when the account already exists and is working.
 **On your local machine** — generate a new key pair:
 
 ```bash
-ssh-keygen -t ed25519 -C "gh-action-forex-tools-deployBoiz" -f ~/.ssh/deployBoiz_ed25519_new
+ssh-keygen -t ed25519 -C "gh-action-forex-tools-dev-deployBoiz" -f ~/.ssh/forex-tools-dev-deployBoiz
 ```
 
 **On the VPS (as root)** — replace the old key:
@@ -326,7 +326,7 @@ cat /home/deployBoiz/.ssh/authorized_keys
 **Test before updating GitHub secret:**
 
 ```bash
-ssh -i ~/.ssh/deployBoiz_ed25519_new \
+ssh -i ~/.ssh/forex-tools-dev-deployBoiz \
     -p <VPS_SSH_PORT> \
     -o PasswordAuthentication=no \
     deployBoiz@<VPS_HOST> "echo ok"

--- a/GUIDE.md
+++ b/GUIDE.md
@@ -279,10 +279,10 @@ HTTPS is automatic — Caddy provisions Let's Encrypt certificates on first requ
 
 ```bash
 mkdir -p /opt/projects/forextools-dev
-mkdir -p /opt/projects/forextools-master
 chown -R deployBoiz:boiz /opt/projects/forextools-dev
-chown -R deployBoiz:boiz /opt/projects/forextools-master
 chmod 775 /opt/projects/forextools-dev
+mkdir -p /opt/projects/forextools-master
+chown -R deployBoiz:boiz /opt/projects/forextools-master
 chmod 775 /opt/projects/forextools-master
 ```
 
@@ -308,7 +308,7 @@ Use this when rotating keys or when the account already exists and is working.
 **On your local machine** — generate a new key pair:
 
 ```bash
-ssh-keygen -t ed25519 -C "gh-action-forex-tools-deployBoiz" -f ~/.ssh/deployBoiz_ed25519_new -N ""
+ssh-keygen -t ed25519 -C "gh-action-forex-tools-deployBoiz" -f ~/.ssh/deployBoiz_ed25519_new
 ```
 
 **On the VPS (as root)** — replace the old key:

--- a/GUIDE.md
+++ b/GUIDE.md
@@ -1,6 +1,6 @@
 # ForexTools — Setup Guide
 
-CI/CD only does: sync compose files → pull image → compose up → health check. Everything else is one-time manual setup.
+CI/CD does two things: (1) on PR merge to `dev`, deploy to dev. (2) On `vX.Y.Z` tag push, deploy to master. Preview images are built on every PR push. Everything else is one-time manual setup.
 
 ---
 
@@ -351,12 +351,46 @@ Set these in **both** the `dev` and `master` environments (repo → Settings →
 | `DEV_DOMAIN` | Variable | `forextoolsdev.americ.io.vn` | same |
 | `PRD_DOMAIN` | Variable | `forextools.americ.io.vn` | same |
 
-Also set these at the **repository** level (auto-updated by CI/CD after each successful deploy):
-
-- `LAST_GOOD_SHA_DEV`
-- `LAST_GOOD_SHA_MASTER`
-
 > ⚠️ When pasting `VPS_SSH_KEY` into GitHub: paste the **entire private key** including header and footer, with real newlines — do not collapse into a single line.
+
+---
+
+## Releasing to master
+
+Master deploys are triggered by pushing a strict semver tag.
+
+### Cut a release
+
+```bash
+git checkout master
+git pull origin master
+git tag -a v1.0.0 -m "Release 1.0.0"
+git push origin v1.0.0
+```
+
+CI validates the tag (`vX.Y.Z`, strictly greater than the highest existing tag), builds a fresh image tagged `:v1.0.0`, `:latest`, and `:<sha>`, then deploys to the master VPS.
+
+### Roll back
+
+There is no "redeploy old image" button. To roll back, push a new, higher tag pointing at an older commit:
+
+```bash
+git tag -a v1.0.1 <older-good-commit-sha> -m "Rollback to <sha>"
+git push origin v1.0.1
+```
+
+CI will rebuild from that commit and redeploy. This guarantees the rollback artifact is reproducible from source.
+
+### Tag rules
+
+- Strict semver only: `v1.2.3`. No `v1.2`, no `v1.2.3-rc1`, no leading zeros.
+- Must be strictly greater than every existing `v*.*.*` tag in the repo.
+- The very first tag is accepted regardless (no monotonic baseline yet).
+- Annotated tags preferred (`git tag -a`) so `git show v1.2.3` carries a message.
+
+### Dev flow (unchanged)
+
+PR → merge to `dev` → CI deploys to dev.
 
 ---
 
@@ -469,4 +503,3 @@ Delete from both `dev` and `master` environments:
 
 - Secrets: `VPS_HOST`, `VPS_USER`, `VPS_SSH_KEY`, `VPS_SSH_PORT`
 - Variables: `PORT`, `DEV_DOMAIN`, `PRD_DOMAIN`
-- Repo variables: `LAST_GOOD_SHA_DEV`, `LAST_GOOD_SHA_MASTER`


### PR DESCRIPTION
- Replace BabyPips GraphQL with Twelve Data REST API as price source; introduce price source registry
- Split `ci-cd.yml` into `pr.yml` (PR/dev) and `release.yml` (tag → prd) workflows
- `release.yml`: validate-tag job enforces strict SemVer + monotonic version guard before prd deploy
- `deploy-vps`: skip HTTPS/Caddy health checks for `master` env
- `pr.yml`: add `paths-ignore: ['**.md']` — doc-only pushes no longer trigger builds
- `GUIDE.md`: update SSH key rotation guide + naming convention
