### PR TITLE
👷 build: opt into Node.js 24 for GitHub Actions runners

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -23,6 +23,7 @@ permissions:
 env:
   ENV: ${{ github.event.pull_request.base.ref }}
   PR: ${{ github.event.pull_request.number }}
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
 jobs:
   # ────────────────────────────────────────────────────────────

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,6 +15,9 @@ permissions:
   packages: write
   actions: write
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   # ────────────────────────────────────────────────────────────
   # Lowercase the repo owner (GHCR requires lowercase paths)


### PR DESCRIPTION
Set FORCE_JAVASCRIPT_ACTIONS_TO_NODE24=true in both pr.yml and release.yml ahead of the June 2026 forced cutoff.