### PR TITLE
👷 build: upgrade GitHub Actions to Node.js 24

### DIFF
--- a/.github/actions/build-docker/action.yml
+++ b/.github/actions/build-docker/action.yml
@@ -31,9 +31,9 @@ outputs:
 runs:
   using: "composite"
   steps:
-    - uses: docker/setup-buildx-action@v3
+    - uses: docker/setup-buildx-action@v4
 
-    - uses: docker/login-action@v3
+    - uses: docker/login-action@v4
       with:
         registry: ghcr.io
         username: ${{ github.actor }}

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -23,6 +23,7 @@ permissions:
 env:
   ENV: ${{ github.event.pull_request.base.ref }}
   PR: ${{ github.event.pull_request.number }}
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
 jobs:
   # ────────────────────────────────────────────────────────────

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -45,7 +45,7 @@ jobs:
     if: github.event.action != 'closed'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: ./.github/actions/build-docker
         with:
           owner_lc: ${{ needs.setup.outputs.owner_lc }}
@@ -63,7 +63,7 @@ jobs:
     if: github.event.pull_request.merged == true && github.event.pull_request.base.ref == 'dev'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: ./.github/actions/build-docker
         with:
           owner_lc: ${{ needs.setup.outputs.owner_lc }}
@@ -82,7 +82,7 @@ jobs:
     environment: dev
     timeout-minutes: 15
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: ./.github/actions/deploy-vps
         with:
           owner_lc: ${{ needs.setup.outputs.owner_lc }}
@@ -106,7 +106,7 @@ jobs:
     if: always() && github.event.action == 'closed'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: ./.github/actions/cleanup
         with:
           owner_lc: ${{ needs.setup.outputs.owner_lc }}
@@ -123,7 +123,7 @@ jobs:
     if: always()
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: ./.github/actions/deploy-summary
         with:
           target_env: ${{ env.ENV }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,6 +15,9 @@ permissions:
   packages: write
   actions: write
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   # ────────────────────────────────────────────────────────────
   # Lowercase the repo owner (GHCR requires lowercase paths)

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,7 +40,7 @@ jobs:
       version: ${{ steps.guard.outputs.version }}
       commit_sha: ${{ steps.guard.outputs.commit_sha }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
           fetch-tags: true
@@ -120,7 +120,7 @@ jobs:
     needs: [setup, validate-tag]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: ./.github/actions/build-docker
         with:
           owner_lc: ${{ needs.setup.outputs.owner_lc }}
@@ -139,7 +139,7 @@ jobs:
     environment: master
     timeout-minutes: 15
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: ./.github/actions/deploy-vps
         with:
           owner_lc: ${{ needs.setup.outputs.owner_lc }}
@@ -164,7 +164,7 @@ jobs:
     if: always()
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
           fetch-tags: true


### PR DESCRIPTION
## What
- `actions/checkout`: v4 → v5 (Node 24 native)
- `docker/login-action`: v3 → v4 (Node 24 native)
- `docker/setup-buildx-action`: v3 → v4 (Node 24 native)
- Add `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true` env in `pr.yml` and `release.yml`

## Why
Node.js 20 actions are deprecated — forced cutoff on GitHub runners is June 2, 2026.
